### PR TITLE
나호균 / 8월 1주차 / 월

### DIFF
--- a/Nahokyun/boj/boj1992.java
+++ b/Nahokyun/boj/boj1992.java
@@ -1,0 +1,51 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class boj1992 {
+    public static int[][] arr;
+    public static int n;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br=new BufferedReader(new InputStreamReader(System.in));
+
+        n=Integer.parseInt(br.readLine());
+        arr=new int[n][n];
+        for(int i=0;i<n;i++){
+            String input=br.readLine();
+            for(int j=0;j<n;j++){
+                arr[i][j]=input.charAt(j)-'0';
+            }
+        }
+        recur(0,0,n);
+    }
+    private static void recur(int startX,int startY,int n){
+        int cur=arr[startY][startX];
+        boolean flag=false;
+        if(n==1){
+            System.out.printf("%d",cur);
+            return;
+        }
+        for(int i=startY;i<startY+n;i++){
+            for(int j=startX;j<startX+n;j++){
+                if(cur!=arr[i][j]){
+                    flag=true;
+                    break;
+                }
+            }
+            if(flag)
+                break;
+        }
+        if(!flag)
+            System.out.printf("%d",cur);
+        else{
+            System.out.printf("(");
+            recur(startX,startY,n/2);
+            recur(startX+n/2,startY,n/2);
+            recur(startX,startY+n/2,n/2);
+            recur(startX+n/2,startY+n/2,n/2);
+            System.out.printf(")");
+        }
+    }
+}

--- a/Nahokyun/boj/boj2447.java
+++ b/Nahokyun/boj/boj2447.java
@@ -1,0 +1,48 @@
+package boj;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.Scanner;
+
+public class boj2447 {
+    public static int n;
+    public static char[][] arr;
+    public static void main(String[] args) throws IOException {
+        Scanner sc=new Scanner(System.in);
+        BufferedWriter bw=new BufferedWriter(new OutputStreamWriter(System.out));
+        n=sc.nextInt();
+        arr=new char[n][n];
+        recur(0,0,n);
+
+        for(char[] i:arr){
+            bw.write(i);
+            bw.write('\n');
+            bw.flush();
+        }
+    }
+
+    private static void recur(int startY,int startX,int n) {
+        if(n==0)
+            return;
+        for(int i=startY;i<n;i++){
+            for(int j=startX;j<n;j++){
+                arr[i][j]='*';
+            }
+        }
+        for(int i=startY+n/3;i<startY+2*n/3;i++){
+            for(int j=startX+n/3;j<startX+2*n/3;j++){
+                arr[i][j]=' ';
+            }
+        }
+        recur(startY,startX,n/3);
+        recur(startY,startX+n/3,n/3);
+        recur(startY,startX+2*n/3,n/3);
+        recur(startY+n/3,startX,n/3);
+        recur(startY+n/3,startX+n/3,n/3);
+        recur(startY+n/3,startX+2*n/3,n/3);
+        recur(startY+2*n/3,startX,n/3);
+        recur(startY+2*n/3,startX+n/3,n/3);
+        recur(startY+2*n/3,startX+2*n/3,n/3);
+    }
+}

--- a/Nahokyun/boj/boj4779.java
+++ b/Nahokyun/boj/boj4779.java
@@ -1,0 +1,36 @@
+package boj;
+
+import java.io.*;
+import java.util.Arrays;
+
+public class boj4779 {
+    public static int n;
+    public static char[] arr;
+    public static int size;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br=new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw=new BufferedWriter(new OutputStreamWriter(System.out));
+        String input;
+        while((input=br.readLine())!=null){
+            n= Integer.parseInt(input);
+            size=(int) Math.pow(3,n);
+            arr=new char[size];
+            Arrays.fill(arr,'-');
+            recur(0,size);
+
+            bw.write(arr);
+            bw.write("\n");
+            bw.flush();
+        }
+
+    }
+    private static void recur(int startX, int n){
+        if(n==0)
+            return;
+        for(int i=startX+n/3;i<startX+2*n/3;i++){
+            arr[i]=' ';
+        }
+        recur(startX,n/3);
+        recur(startX+2*n/3,n/3);
+    }
+}


### PR DESCRIPTION
# 8월 1주차 월
저는 전체적으로 재귀호출 문제를 풀때(특히 별찍기 문제) 바로 별을 찍는것이 아닌 전체 배열을 선언하고 재귀함수에 시작 좌표를 파라미터로 넘겨주는 방식을 자주 사용합니다
하지만 이렇게하면 배열을 선언하는데 있어 메모리를 많이 잡아먹는 방향으로 흘러가는것 같습니다! 
혹시 배열을 사용하지않고 바로바로 출력할 수 있는 방법을 알고계시다면 접근을 어떻게 시도하시는지 알려주시면 감사하겠습니다!

## [칸토어 집합-BOJ 4779]
```java
import java.io.*;
import java.util.Arrays;

public class boj4779 {
    public static int n;
    public static char[] arr;
    public static int size;
    public static void main(String[] args) throws IOException {
        BufferedReader br=new BufferedReader(new InputStreamReader(System.in));
        BufferedWriter bw=new BufferedWriter(new OutputStreamWriter(System.out));
        String input;
        while((input=br.readLine())!=null){
            n= Integer.parseInt(input);
            size=(int) Math.pow(3,n);
            arr=new char[size];
            Arrays.fill(arr,'-');
            recur(0,size);

            bw.write(arr);
            bw.write("\n");
            bw.flush();
        }
    }
    private static void recur(int startX, int n){
        if(n==0)
            return;
        for(int i=startX+n/3;i<startX+2*n/3;i++){
            arr[i]=' ';
        }
        recur(startX,n/3);
        recur(startX+2*n/3,n/3);
    }
}
```
### 접근1
주어진 n에 해당하는 size로 char배열을 선언하고 3등분하여 길이와 시작 좌표를 파라미터로 재귀호출

## [쿼드트리-BOJ 1992]
```java
import java.io.BufferedReader;
import java.io.IOException;
import java.io.InputStreamReader;

public class boj1992 {
    public static int[][] arr;
    public static int n;
    public static void main(String[] args) throws IOException {
        BufferedReader br=new BufferedReader(new InputStreamReader(System.in));

        n=Integer.parseInt(br.readLine());
        arr=new int[n][n];
        for(int i=0;i<n;i++){
            String input=br.readLine();
            for(int j=0;j<n;j++){
                arr[i][j]=input.charAt(j)-'0';
            }
        }
        recur(0,0,n);
    }
    private static void recur(int startX,int startY,int n){
        int cur=arr[startY][startX];
        boolean flag=false;
        if(n==1){
            System.out.printf("%d",cur);
            return;
        }
        for(int i=startY;i<startY+n;i++){
            for(int j=startX;j<startX+n;j++){
                if(cur!=arr[i][j]){
                    flag=true;
                    break;
                }
            }
            if(flag)
                break;
        }
        if(!flag)
            System.out.printf("%d",cur);
        else{
            System.out.printf("(");
            recur(startX,startY,n/2);
            recur(startX+n/2,startY,n/2);
            recur(startX,startY+n/2,n/2);
            recur(startX+n/2,startY+n/2,n/2);
            System.out.printf(")");
        }
    }
}

```
### 접근 1
압축을 하는 경우의 수는 4가지로 나뉘기에 각 구역의 시작좌표와 n의 크기를 넘겨서 재귀호출

## [별찍기10-BOJ 2447]
```java
import java.io.BufferedWriter;
import java.io.IOException;
import java.io.OutputStreamWriter;
import java.util.Scanner;

public class boj2447 {
    public static int n;
    public static char[][] arr;
    public static void main(String[] args) throws IOException {
        Scanner sc=new Scanner(System.in);
        BufferedWriter bw=new BufferedWriter(new OutputStreamWriter(System.out));
        n=sc.nextInt();
        arr=new char[n][n];
        recur(0,0,n);

        for(char[] i:arr){
            bw.write(i);
            bw.write('\n');
            bw.flush();
        }
    }

    private static void recur(int startY,int startX,int n) {
        if(n==0)
            return;
        for(int i=startY;i<n;i++){
            for(int j=startX;j<n;j++){
                arr[i][j]='*';
            }
        }
        for(int i=startY+n/3;i<startY+2*n/3;i++){
            for(int j=startX+n/3;j<startX+2*n/3;j++){
                arr[i][j]=' ';
            }
        }
        recur(startY,startX,n/3);
        recur(startY,startX+n/3,n/3);
        recur(startY,startX+2*n/3,n/3);
        recur(startY+n/3,startX,n/3);
        recur(startY+n/3,startX+n/3,n/3);
        recur(startY+n/3,startX+2*n/3,n/3);
        recur(startY+2*n/3,startX,n/3);
        recur(startY+2*n/3,startX+n/3,n/3);
        recur(startY+2*n/3,startX+2*n/3,n/3);
    }
}

```
### 접근1
별이 찍히는 모양을 보면 크게 9가지 구역으로 나눠 가운데 공간만 비우는 모양으로 구성
별을 표현하는데 필요한 크기만큼의 이차원 배열을 선언 후 시작 좌표와 n의 크기를 넘겨서 재귀호출

## 출력 시간 비교
배열을 출력하는데 시간초과가 나오는 상황이 여러번 발생 
-> 기존의 for문에서 foreach문을 사용, 시간초과 발생
-> BufferedWriter를 통한 출력 사용, 통과

출력 속도 관련 검색해보다가 배열에서는 for문이 forEach문보다 빠르다 라는 이야기도 있길래
아래의 코드를 통해 출력 시간을 직접 비교해봤습니다 (입력은 테케와 같이 27)
```java
        // BufferedWriter사용 
        long tcheck_st=System.nanoTime();
        for(char[] i:arr){
            bw.write(i);
            bw.write('\n');
            bw.flush();
        }
        long tcheck_fi=System.nanoTime();
        System.out.println(tcheck_fi-tcheck_st);
        
        
        // for문 사용 
        tcheck_st=System.nanoTime();
        for(int i=0;i<n;i++){
            for(int j=0;j<n;j++)
                System.out.printf(String.valueOf(arr[i][j]));
            System.out.println();
        }
        tcheck_fi=System.nanoTime();
        System.out.println(tcheck_fi-tcheck_st);
        tcheck_st=System.nanoTime();
        
        //forEach문 사용
        for(char[] i:arr){
            for(char j:i)
                System.out.printf(String.valueOf(j));
            System.out.println();
        }
        tcheck_fi=System.nanoTime();
        System.out.println(tcheck_fi-tcheck_st);
```
BufferWriter+ForEach - 309600ns
For문+printf                - 7841800ns
ForEach문+printf        - 3728300ns


