### PR TITLE
소재열 / 8월 1주차 / 목

### DIFF
--- a/jaeyeol/boj/Boj11729.java
+++ b/jaeyeol/boj/Boj11729.java
@@ -1,0 +1,32 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class Boj11729 {
+
+    static StringBuilder result = new StringBuilder();
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int count = (2 << n - 1) - 1;
+
+        if (n <= 20) {
+            hanoi(n, 1, 2, 3);
+            System.out.println(count + "\n" + result);
+        } else {
+            System.out.println(count);
+        }
+    }
+
+    private static void hanoi(int n, int start, int mid, int end) {
+        if (n == 1) {
+            result.append(start).append(" ").append(end).append("\n");
+            return;
+        }
+
+        hanoi(n - 1, start, end, mid);
+        result.append(start).append(" ").append(end).append("\n");
+        hanoi(n - 1, mid, start, end);
+    }
+
+}

--- a/jaeyeol/boj/Boj1436.java
+++ b/jaeyeol/boj/Boj1436.java
@@ -1,0 +1,46 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Boj1436 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        System.out.println(getTitle(n));
+    }
+
+    private static String getTitle(int n) {
+        int left = 0;
+        int right = -1;
+
+        while (--n > 0) {
+            left++;
+
+            if (left % 10 == 6) {
+                int leftNumber = left;
+                int count = 1;
+                int formatCount = 0;
+                while (leftNumber % 10 == 6) {
+                    leftNumber /= 10;
+                    count *= 10;
+                    formatCount++;
+                }
+
+                while (++right < count) {
+                    if (--n <= 0) {
+                        return (leftNumber != 0 ? leftNumber : "") + "666" + String.format("%0" + formatCount + "d", right);
+                    }
+                }
+                right = -1;
+                left++;
+            }
+        }
+
+        return (left != 0 ? left : "") + "666";
+    }
+
+
+}
+

--- a/jaeyeol/boj/Boj14500.java
+++ b/jaeyeol/boj/Boj14500.java
@@ -1,0 +1,84 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Boj14500 {
+    static int[][] map;
+    static int[][] dirs = {{1, 0}, {0, 1}, {-1, 0}, {0, -1}};
+    static int n, m;
+    static boolean[][] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        map = new int[n][m];
+        visited = new boolean[n][m];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int result = 0;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                result = Math.max(result, dfs(i, j, 1));
+                result = Math.max(result, spacialCase(i, j));
+            }
+        }
+
+        System.out.println(result);
+    }
+
+    // 4칸 이동 경로
+    private static int dfs(int i, int j, int depth) {
+        if (depth > 3) {
+            return map[i][j];
+        }
+        visited[i][j] = true;
+
+        int max = 0;
+        for (int[] dir : dirs) {
+            int x = dir[0] + i;
+            int y = dir[1] + j;
+
+            if (x < 0 || y < 0 || x >= n || y >= m || visited[x][y]) {
+                continue;
+            }
+
+            max = Math.max(max, dfs(x, y, depth + 1));
+        }
+
+        visited[i][j] = false;
+        return map[i][j] + max;
+    }
+
+    // ㅗ 모양
+    private static int spacialCase(int i, int j) {
+        int sum = map[i][j];
+        int min = Integer.MAX_VALUE;
+        int count = 0;
+
+        for (int[] dir : dirs) {
+            int x = dir[0] + i;
+            int y = dir[1] + j;
+
+            if (x < 0 || y < 0 || x >= n || y >= m) {
+                continue;
+            }
+
+            count++;
+            sum += map[x][y];
+            min = Math.min(min, map[x][y]);
+        }
+
+        return count < 3 ? 0 : (count == 3 ? sum : sum - min);
+    }
+
+}
+

--- a/jaeyeol/boj/Boj14502.java
+++ b/jaeyeol/boj/Boj14502.java
@@ -1,0 +1,90 @@
+import java.awt.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.List;
+
+public class Boj14502 {
+    static List<Point> virus;
+    static int[][] map;
+    static int n, m, virusCount = Integer.MAX_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        map = new int[n][m];
+        virus = new ArrayList<>();
+
+        int totalArea = 0;
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+                if (map[i][j] == 0) {
+                    totalArea++;
+                } else if (map[i][j] == 2) {
+                    virus.add(new Point(i, j));
+                }
+            }
+        }
+
+        dfs(0, 0, 0);
+        System.out.println(totalArea - virusCount - 3);
+    }
+
+    private static void dfs(int depth, int x, int y) {
+        if (depth == 3) {
+            virusCount = Math.min(virusCount, bfs());
+            return;
+        }
+
+        for (int i = x; i < map.length; i++) {
+            for (int j = (i == x ? y : 0); j < map[i].length; j++) {
+                if (map[i][j] <= 0) {
+                    map[i][j] = 1;
+                    dfs(depth + 1, i, j);
+                    map[i][j] = 0;
+                }
+            }
+        }
+    }
+
+    static int[][] dirs = {{1, 0}, {0, 1}, {-1, 0}, {0, -1}};
+    static int season;
+
+    static Queue<Point> queue = new ArrayDeque<>();
+    private static int bfs() {
+        season--;
+        queue.addAll(virus);
+
+        int count = 0;
+        while (!queue.isEmpty()) {
+            Point cur = queue.poll();
+
+            for (int[] dir : dirs) {
+                int x = dir[0] + cur.x;
+                int y = dir[1] + cur.y;
+
+                if (x < 0 || y < 0 || x >= n || y >= m || map[x][y] > 0 || map[x][y] == season) {
+                    continue;
+                }
+                map[x][y] = season;
+                queue.add(new Point(x, y));
+                count++;
+            }
+
+            if (count >= virusCount) {
+                queue.clear();
+                return count;
+            }
+        }
+
+        return count;
+    }
+
+}
+

--- a/jaeyeol/boj/Boj2503.java
+++ b/jaeyeol/boj/Boj2503.java
@@ -1,0 +1,81 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Boj2503 {
+    static class BaseBall {
+        int[] number;
+        int strike;
+        int ball;
+
+        public BaseBall(String number, int strike, int ball) {
+            this.number = new int[number.length()];
+            for (int i = 0; i < number.length(); i++) {
+                this.number[i] = number.charAt(i) - '0';
+            }
+            this.strike = strike;
+            this.ball = ball;
+        }
+
+        public boolean isTrue(int[] number) {
+            int strike = 0;
+            int ball = 0;
+
+            for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < 3; j++) {
+                    if (this.number[i] == number[j]) {
+                        if (i == j) {
+                            strike++;
+                        } else {
+                            ball++;
+                        }
+                    }
+                }
+            }
+
+            return this.strike == strike && this.ball == ball;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        baseBalls = new BaseBall[n];
+
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            String number = st.nextToken();
+            int strike = Integer.parseInt(st.nextToken());
+            int ball = Integer.parseInt(st.nextToken());
+
+            baseBalls[i] = new BaseBall(number, strike, ball);
+        }
+
+        dfs(new int[3], new boolean[10], 0);
+        System.out.println(count);
+    }
+
+    static int count;
+    static BaseBall[] baseBalls;
+
+    static void dfs(int[] number, boolean[] visited, int depth) {
+        if (depth >= number.length) {
+            for (BaseBall baseBall : baseBalls) {
+                if (!baseBall.isTrue(number)) {
+                    return;
+                }
+            }
+            count++;
+            return;
+        }
+
+        for (int i = 1; i <= 9; i++) {
+            if (!visited[i]) {
+                number[depth] = i;
+                visited[i] = true;
+                dfs(number, visited, depth + 1);
+                visited[i] = false;
+            }
+        }
+    }
+}

--- a/jaeyeol/boj/Boj2508.java
+++ b/jaeyeol/boj/Boj2508.java
@@ -1,0 +1,64 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Boj2508 {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = Integer.parseInt(br.readLine());
+
+        StringBuilder result = new StringBuilder();
+        while (t-- > 0) {
+            br.readLine();
+            StringTokenizer st = new StringTokenizer(br.readLine());
+
+            int n = Integer.parseInt(st.nextToken());
+            int m = Integer.parseInt(st.nextToken());
+
+            char[][] box = new char[n][m];
+
+            for (int i = 0; i < n; i++) {
+                String str = br.readLine();
+                for (int j = 0; j < m; j++) {
+                    box[i][j] = str.charAt(j);
+                }
+            }
+
+            result.append(getCandies(box)).append("\n");
+        }
+
+        System.out.println(result);
+    }
+
+    private static int getCandies(char[][] box) {
+        int candy = 0;
+
+        for (int i = 0; i < box.length; i++) {
+            for (int j = 0; j < box[i].length; j++) {
+                if (box[i][j] == CANDY_TYPE[4] && isCandy(box, i, j)) {
+                    candy++;
+                }
+            }
+        }
+
+        return candy;
+    }
+
+    static final char[] CANDY_TYPE = {'>', '<', 'v', '^', 'o'};
+
+    private static boolean isCandy(char[][] box, int i, int j) {
+        if (j > 0 && j < box[i].length - 1) {
+            if (box[i][j - 1] == CANDY_TYPE[0] && box[i][j + 1] == CANDY_TYPE[1]) {
+                return true;
+            }
+        }
+
+        if (i > 0 && i < box.length - 1) {
+            return box[i - 1][j] == CANDY_TYPE[2] && box[i + 1][j] == CANDY_TYPE[3];
+        }
+
+        return false;
+    }
+
+}


### PR DESCRIPTION
## 2508번, 사탕 박사 고창영
- 사탕의 알 모양을 찾아서 주변 동서남북 방향으로 껍질 모양이 있는지 체크하는 방향으로 풀이했습니다.

## 2503번, 숫자 야구
- 재귀 순열을 이용해 숫자의 모든 경우의 수를 만들고 질의들을 통과하는지 체크하는 방향으로 풀이했습니다.

## 1436, 영화감독 숌
- 666을 무조건 넣은 상태에서 666의 좌측과 우측의 패턴의 규칙이 있는 것을 이용해서 카운팅하면서 풀이했습니다.

## 11729, 하노이 탑 이동 순서
- 웰넌 문제인 만큼 정석으로 풀이했습니다.

## 14500, 테트로미노
- dfs로 4칸의 이동경로의 합으로 4개의 블럭들의 경우의 수를 처리해주었습니다.
- ㅗ모양의 블럭은 특수 케이스로 가운데 블럭을 기준으로 삼아서 동서남북의 4개방향을 보고 3개의 합이 최대가 되는 경우를 반환하는 식으로 풀이했습니다.

## 14502, 연구소
- dfs로 벽의 경우의 수를 찾고 bfs로 바이러스를 퍼트리는 시뮬레이션을 돌렸습니다.
- isBlock() 은 벽을 놓을 때 생각해보면 벽이 어떠한 길을 막았을 때 비로소 의미있는 벽이라고 생각하여 주변 방향을 탐색하여 벽이 있을 때만 돌아가게 끔 최적화를 시도해보았습니다. 유의미한 큰 효과는 없었지만 메모리와 시간이 최적화되긴했습니다. 

