### PR TITLE
임예준 / 8월 2주차 / 월

### DIFF
--- a/dpwns/boj/boj10972.java
+++ b/dpwns/boj/boj10972.java
@@ -1,0 +1,40 @@
+import java.util.*;
+import java.io.*;
+
+class Main
+{
+    public static void main(String args[]) throws Exception
+    {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int[] permutation = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+        int st = n-1, minIdx = n-1;
+        while(st > 0) {
+            if(permutation[st] > permutation[st-1]) {   // 맨 뒤에서 부터 오름 차순 찾기 7 9 8 -> 9 8이오름차순의 끝이므로 8과 7을 바꾸고 sort -> 879
+                int finalSt = st - 1;
+                int min = Arrays.stream(permutation, st, n).filter(p -> p > permutation[finalSt]).min().getAsInt();
+                for(int i=st; i<n; i++) {
+                    if(min == permutation[i]) {
+                        minIdx = i;
+                        break;
+                    }
+                }
+                break;
+            }
+            st--;
+        }
+        if(st == 0) System.out.println("-1");
+        else {
+            int tmp = permutation[st-1];
+            permutation[st-1] = permutation[minIdx];
+            permutation[minIdx] = tmp;
+            Arrays.sort(permutation, st, n);
+
+            StringBuilder sb = new StringBuilder();
+            Arrays.stream(permutation).forEach(p -> sb.append(p).append(" "));
+            System.out.println(sb);
+        }
+
+        br.close();
+    }
+}

--- a/dpwns/boj/boj10973.java
+++ b/dpwns/boj/boj10973.java
@@ -1,0 +1,39 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+
+        Integer[] permutation = Arrays.stream(br.readLine().split(" ")).map(Integer::parseInt).toArray(Integer[]::new);
+
+        int st = n-1, maxIdx = n-1;
+        while(st > 0) {
+            if(permutation[st] < permutation[st-1]) {
+                // 1 2 5 3 4 -> 이전 순열은 1 2 4 5 3 맨 뒤에서 부터 봤을 때 오름차순이 되는 순간 5보다 작으면서 최댓값과 5를 바꾸고 내림차순 정렬
+                int max = Integer.MIN_VALUE;
+                for (int i = st; i < n; i++) {
+                    if (permutation[i] < permutation[st-1] && permutation[i] > max) {
+                        max = permutation[i];
+                        maxIdx = i;
+                    }
+                }
+                break;
+            }
+            st--;
+        }
+        if(st == 0) System.out.println("-1");
+        else {
+            int tmp = permutation[st-1];
+            permutation[st-1] = permutation[maxIdx];
+            permutation[maxIdx] = tmp;
+            Arrays.sort(permutation, st, n, (p1, p2) -> p2 - p1);
+            StringBuilder sb = new StringBuilder();
+            Arrays.stream(permutation).forEach(p -> sb.append(p).append(" "));
+            System.out.println(sb);
+        }
+        br.close();
+    }
+}

--- a/dpwns/boj/boj10974.java
+++ b/dpwns/boj/boj10974.java
@@ -1,0 +1,36 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    public static StringBuilder sb = new StringBuilder();
+    public static int n;
+    public static int[] seq, visited;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        seq = new int[n];
+        visited = new int[n+1];
+        permutation( 0);
+
+        System.out.print(sb);
+
+        br.close();
+    }
+
+    public static void permutation(int cnt) {
+        if(cnt == n) {
+            Arrays.stream(seq).forEach(s -> sb.append(s).append(" "));
+            sb.append("\n");
+            return;
+        }
+
+        for(int i=1; i<=n; i++) {
+            if(visited[i] == 0) {
+                seq[cnt] = i;
+                visited[i] = 1;
+                permutation(cnt+1);
+                visited[i] = 0;
+            }
+        }
+    }
+}

--- a/dpwns/boj/boj1325.java
+++ b/dpwns/boj/boj1325.java
@@ -1,0 +1,42 @@
+import java.util.*;
+import java.io.*;
+
+class Main {
+    public static int max = 0, cnt = 0;
+    public static List<ArrayList<Integer>> graph = new ArrayList<>();
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken()), m = Integer.parseInt(st.nextToken());
+        for(int i=0; i<=n; i++) {
+            graph.add(new ArrayList<>());
+        }
+        for(int i=0; i<m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken()), b = Integer.parseInt(st.nextToken());
+            graph.get(b).add(a);
+        }
+        int[] result = new int[n+1];
+        for(int i=1; i<=n; i++) {
+            int[] visited = new int[n+1];
+            visited[i] = 1;
+            cnt = 0;
+            dfs(i, visited);
+            result[i] = cnt;
+            max = Math.max(max, cnt);
+        }
+        for(int i=1; i<=n; i++) {
+            if(max == result[i]) System.out.print(i + " ");
+        }
+        br.close();
+    }
+    public static void dfs(int start, int[] visited) {
+        for(int next : graph.get(start)) {
+            if(visited[next] == 0) {    // 사이클이 있을 수 있음
+                visited[next] = 1;
+                cnt++;
+                dfs(next, visited);
+            }
+        }
+    }
+}

--- a/dpwns/boj/boj1697.java
+++ b/dpwns/boj/boj1697.java
@@ -1,0 +1,42 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    static class Location {
+        int pos, time;
+        public Location(int pos, int time) {
+            this.pos = pos;
+            this.time = time;
+        }
+    }
+    public static final int MAX_LOC = 100000;
+    public static int[] direction = {1, -1, 2};
+    public static int n, k;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        System.out.println(move(n));
+        br.close();
+    }
+
+    public static int move(int curr) {
+        Set<Integer> set = new HashSet<>();
+        Queue<Location> queue = new LinkedList<>();
+        queue.offer(new Location(curr, 0));
+        set.add(curr);
+        while (!queue.isEmpty()) {
+            Location loc = queue.poll();
+            if (loc.pos == k) return loc.time;
+            for (int i = 0; i < direction.length; i++) {
+                int next = i == 2 ? loc.pos * direction[i] : loc.pos + direction[i];
+                if (!set.contains(next) && next >= 0 && next <= MAX_LOC) {
+                    set.add(next);
+                    queue.offer(new Location(next, loc.time + 1));
+                }
+            }
+        }
+        return -1;
+    }
+}

--- a/dpwns/boj/boj2004.java
+++ b/dpwns/boj/boj2004.java
@@ -1,0 +1,24 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken()), m = Integer.parseInt(st.nextToken());
+
+        int totalFive = cntDiv(n, 5) - cntDiv(n-m, 5) - cntDiv(m, 5);
+        int totalTwo = cntDiv(n, 2) -cntDiv(n-m, 2) - cntDiv(m, 2);
+        System.out.println(Math.min(totalFive, totalTwo));
+        br.close();
+    }
+
+    public static int cntDiv(int n, int div) {
+        int cnt = 0;
+        while(n > 0) {
+            cnt += n / div;
+            n /= div;
+        }
+        return cnt;
+    }
+}

--- a/dpwns/boj/boj24230.java
+++ b/dpwns/boj/boj24230.java
@@ -1,0 +1,32 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    /*
+        1. 초기 모든 노드는 흰색이다
+        2. 부모 노드를 칠하면 자식 노드들도 같은색으로 칠해짐
+        3. 입력 상태를 보면 부모와 자식 노드의 색이 다른 상황 -> 자식노드가 어떤 서브트리의 부모노드역할로 색칠한 경우를 뜻함
+        --> 서브트리의 root 역할로 선택된 노드의 개수를 찾는다
+     */
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[] color = new int[n+1];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i=1; i<=n; i++) {
+            color[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int cnt = 0;
+        for(int i=0; i<n-1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken()), b = Integer.parseInt(st.nextToken());
+            // 연결된 노드의 색이 다르다는 것은 한 노드가 어떤 서브트리의 루트노드로 색칠되었다는 의미
+            if(color[a] != color[b]) cnt++;
+        }
+        System.out.println(color[1] != 0 ? cnt+1 : cnt);    // 전체 트리의 root노드 체크
+        br.close();
+    }
+}


### PR DESCRIPTION
## BOJ10972 다음 순열

 - 입력으로 주어진 순열의 다음 순열을 찾는 문제였습니다
  - 1 2 3의 다음 순열은 1 3 2, 2 1 3 ...입니다
  - 순열의 맨 뒤 부터(역순)으로 1 2 3을 보면 3 -> 2로 내림차순 형태면 두 위치를 바꿉니다 (왜 갑자기 바꿈?)
  - 1 3 2를 보면 2 -> 3은 오름차순을 유지하지만 3 -> 1은 내림차순 형태로 1과 3,2중 하나를 바꿔야합니다(왜 why?)
  - 사전순이기 때문에 3과 2중 작은 수가 1과 바뀌고 그 뒤는 1 3 으로 정렬된 상태를 유지합니다 2 1 3 
  - 2 3 1이라면 3 ->2가 내림차순이되고 2와 3,1중 하나가 바뀌는데 2보다 큰 수와 바뀌어야 사전순이 됩니다

## BOJ10973 이전 순열

 - 다음 순열과 비슷하게 내림차순 형태 -> 오름차순 형태일 때 두 위치를 변경하면 됩니다
 - 1 3 2의 이전 순열은 2 -> 3이 오름차순이므로 두 위치를 변경
 - 사전순으로 정렬하기 위해선 3보다 작고 그 구간에서 최대 값을 찾아서 변경
 
## BOJ10974 모든 순열

 - 수업시간에 배운대로 했습니다

## BOJ2004 조합 0의 개수

 - nCr에서 0의 개수를 구하는 문제
 - 0을 만들기 위해선 2x5가 필요해서 가능한 2와 5의 개수를 구해 적은 개수가 0의 개수를 나타냄


## BOJ1325 효율적인 해킹	

 - 각 노드를 해킹의 시작점으로 dfs를 돌려 최대 해킹당할 수 있는 개수를 찾았습니다

## BOJ1697 숨바꼭질

 - 현재위치에서 -1, +1, *2 세 방향으로 진행해서 동생을 찾는데, bfs를 사용했습니다
 - bfs를 사용하면 방문했던 위치를 기록해야하는데 이 부분을 visited배열을 사용하게 되면 낭비되는 공간이 발생
    - Set 자료구조로 방문 체크를 하였음
    - 배열 풀이보다 메모리가 절반으로 감소

## BOJ24230 트리 색칠하기

 - 초기에 모든 노드는 흰색인데 입력으로 들어온 값으로 색칠이 되어지려면 최소 몇 번 색칠해야하는 지 찾는 문제
 - 연결된 노드 사이 색이 다르다는 것
   - 나랑 연결된 아래 노드가 서브트리의 루트 노드 역할로 색칠 했다는 의미로 count한다
 - root 노드는 비교할 부모노드가 없으므로 흰색이 아니면 count를 하나 추가 해야 함