### PR TITLE
소재열 / 8월 2주차 / 목

### DIFF
--- a/jaeyeol/boj/Boj01167.java
+++ b/jaeyeol/boj/Boj01167.java
@@ -1,0 +1,74 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+// 트리의 지름
+public class Boj01167 {
+
+    static class Node {
+        int root;
+        int distance;
+        Node next;
+
+        public Node(int root, int distance, Node next) {
+            this.root = root;
+            this.distance = distance;
+            this.next = next;
+        }
+    }
+
+    static int result;
+    static Node[] graphs;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int v = Integer.parseInt(st.nextToken());
+        graphs = new Node[v + 1];
+        for (int i = 1; i <= v; i++) {
+            graphs[i] = new Node(i, 0, null);
+        }
+        visited = new boolean[v + 1];
+
+        for (int i = 0; i < v; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int d;
+            while ((d = Integer.parseInt(st.nextToken())) != -1) {
+                int w = Integer.parseInt(st.nextToken());
+                graphs[s].next = new Node(d, w, graphs[s].next);
+            }
+        }
+
+        System.out.println(Math.max(dfs(1, 0), result));
+    }
+
+    static boolean[] visited;
+
+    private static int dfs(int root, int w) {
+        visited[root] = true;
+
+        int maxChild = 0;
+        int secondMaxChild = 0;
+
+        for (Node next = graphs[root].next; next != null; next = next.next) {
+            if (visited[next.root]) {
+                continue;
+            }
+
+            int childWeight = dfs(next.root, next.distance);
+            if (childWeight > maxChild) {
+                secondMaxChild = maxChild;
+                maxChild = childWeight;
+            } else {
+                secondMaxChild = Math.max(secondMaxChild, childWeight);
+            }
+        }
+
+        result = Math.max(result, maxChild + secondMaxChild); // 연결된 노드 중 가장 긴 노드 2개의 합
+        return maxChild + w; // 연결된 노드 중 가장 긴 노드 반환
+    }
+
+}
+

--- a/jaeyeol/boj/Boj05014.java
+++ b/jaeyeol/boj/Boj05014.java
@@ -1,0 +1,49 @@
+import java.io.*;
+import java.util.*;
+
+// 스타트링크
+public class Boj05014 {
+    static final String FAIL_MSG = "use the stairs";
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int f = Integer.parseInt(st.nextToken());
+        int s = Integer.parseInt(st.nextToken());
+        int g = Integer.parseInt(st.nextToken());
+        int u = Integer.parseInt(st.nextToken());
+        int d = Integer.parseInt(st.nextToken());
+
+        System.out.println(bfs(f, s, g, u, d));
+    }
+
+    private static String bfs(int f, int s, int g, int u, int d) {
+        int[] distance = new int[f + 1];
+        distance[s] = 1;
+
+        Queue<Integer> queue = new ArrayDeque<>();
+        queue.add(s);
+
+        while (!queue.isEmpty()) {
+            Integer cur = queue.poll();
+
+            if (cur - d > 0 && distance[cur - d] == 0) {
+                queue.add(cur - d);
+                distance[cur - d] = distance[cur] + 1;
+            }
+
+            if (cur + u <= f && distance[cur + u] == 0) {
+                queue.add(cur + u);
+                distance[cur + u] = distance[cur] + 1;
+            }
+
+            if (distance[g] > 0) {
+                break;
+            }
+        }
+
+        return distance[g] == 0 ? FAIL_MSG : String.valueOf(distance[g] - 1);
+    }
+
+}
+

--- a/jaeyeol/boj/Boj06593.java
+++ b/jaeyeol/boj/Boj06593.java
@@ -1,0 +1,95 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+//상범 빌딩
+public class Boj06593 {
+    static class Point {
+        int x, y, z;
+
+        public Point(int z, int x, int y) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String read;
+        StringBuilder result = new StringBuilder();
+
+        while (!(read = br.readLine()).equals("0 0 0")) {
+            StringTokenizer st = new StringTokenizer(read, " ");
+            int l = Integer.parseInt(st.nextToken());
+            int n = Integer.parseInt(st.nextToken());
+            int m = Integer.parseInt(st.nextToken());
+
+            char[][][] map = new char[l][n][m];
+            Point person = null, exit = null;
+
+            for (int f = 0; f < l; f++) {
+
+                for (int i = 0; i < n; i++) {
+                    String str = br.readLine();
+                    for (int j = 0; j < m; j++) {
+                        map[f][i][j] = str.charAt(j);
+
+                        if (map[f][i][j] == 'S') {
+                            person = new Point(f, i, j);
+                        } else if (map[f][i][j] == 'E') {
+                            exit = new Point(f, i, j);
+                        }
+                    }
+                }
+                br.readLine();
+            }
+
+            result.append(simulate(map, l, n, m, person, exit)).append("\n");
+        }
+
+        System.out.println(result);
+    }
+
+    static final int[][] dirs = {{0, 1, 0}, {0, 0, 1}, {0, -1, 0}, {0, 0, -1}, {-1, 0, 0}, {1, 0, 0}};
+    static final char WALL = '#', EXIT = 'E';
+
+    private static String simulate(char[][][] map, int l, int n, int m, Point person, Point exit) {
+        Queue<Point> queue = new LinkedList<>();
+        queue.add(person);
+        int time = 0;
+
+        while (!queue.isEmpty()) {
+            time++;
+            Queue<Point> next = new LinkedList<>();
+
+            while (!queue.isEmpty()) {
+                Point cur = queue.poll();
+
+                for (int[] dir : dirs) {
+                    int z = cur.z + dir[0];
+                    int x = cur.x + dir[1];
+                    int y = cur.y + dir[2];
+
+                    if (x < 0 || y < 0 || x >= n || y >= m || z < 0 || z >= l || map[z][x][y] == WALL) {
+                        continue;
+                    } else if (map[z][x][y] == EXIT) {
+                        return "Escaped in " + time + " minute(s).";
+                    }
+
+                    map[z][x][y] = WALL;
+                    next.add(new Point(z, x, y));
+                }
+            }
+
+            queue = next;
+        }
+
+        return "Trapped!";
+    }
+
+
+}
+

--- a/jaeyeol/boj/Boj14716.java
+++ b/jaeyeol/boj/Boj14716.java
@@ -1,0 +1,55 @@
+import java.io.*;
+import java.util.*;
+
+//현수막
+public class Boj14716 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        boolean[][] map = new boolean[n][m];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                map[i][j] = st.nextToken().equals("1");
+            }
+        }
+
+        int count = 0;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (map[i][j]) {
+                    dfs(map, i, j);
+                    count++;
+                }
+            }
+        }
+
+        System.out.println(count);
+    }
+
+    static int[][] dirs = {
+            {-1, -1}, {-1, 0}, {-1, 1},
+            {0, -1}, {0, 1},
+            {1, -1}, {1, 0}, {1, 1}};
+
+    private static void dfs(boolean[][] map, int i, int j) {
+        map[i][j] = false;
+
+        for (int[] dir : dirs) {
+            int x = i + dir[0];
+            int y = j + dir[1];
+
+            if (x < 0 || y < 0 || x >= map.length || y >= map[x].length || !map[x][y]) {
+                continue;
+            }
+            dfs(map, x, y);
+        }
+    }
+
+
+}
+

--- a/jaeyeol/boj/Boj2210.java
+++ b/jaeyeol/boj/Boj2210.java
@@ -1,0 +1,51 @@
+import java.io.*;
+import java.util.*;
+
+// 숫자판 점프
+public class Boj2210 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int[][] map = new int[N][N];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                dfs(map, i, j, 0, 0);
+            }
+        }
+
+        System.out.println(set.size());
+    }
+    static Set<Integer> set = new HashSet<>();
+    static int[][] dirs = {{0, 1}, {1, 0}, {-1, 0}, {0, -1}};
+    static final int N = 5;
+
+    private static void dfs(int[][] map, int i, int j, int depth, int sum) {
+        if (depth > N) {
+            set.add(sum);
+            return;
+        }
+        sum *= 10;
+
+        for (int[] dir : dirs) {
+            int x = i + dir[0];
+            int y = j + dir[1];
+
+            if (x < 0 || y < 0 || x >= N || y >= N) {
+                continue;
+            }
+
+            dfs(map, x, y, depth + 1, sum + map[x][y]);
+        }
+    }
+
+
+}
+

--- a/jaeyeol/boj/Boj5427.java
+++ b/jaeyeol/boj/Boj5427.java
@@ -1,0 +1,105 @@
+import java.awt.*;
+import java.io.*;
+import java.util.*;
+
+// 불
+public class Boj5427 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = Integer.parseInt(br.readLine());
+
+        StringBuilder result = new StringBuilder();
+        while (t-- > 0) {
+            StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+            int m = Integer.parseInt(st.nextToken());
+            int n = Integer.parseInt(st.nextToken());
+            char[][] map = new char[n][m];
+
+            Queue<Point> fires = new LinkedList<>();
+            Point me = null;
+            for (int i = 0; i < n; i++) {
+                String str = br.readLine();
+                for (int j = 0; j < m; j++) {
+                    map[i][j] = str.charAt(j);
+
+                    if (map[i][j] == '*') {
+                        fires.add(new Point(i, j));
+                    } else if (map[i][j] == '@') {
+                        me = new Point(i, j);
+                    }
+                }
+            }
+
+            result.append(simulate(map, fires, me)).append("\n");
+        }
+
+        System.out.println(result);
+    }
+
+    static int[][] dirs = {{-1, 0}, {0, -1}, {0, 1}, {1, 0}};
+
+    private static String simulate(char[][] map, Queue<Point> fires, Point person) {
+        Queue<Point> queue = new LinkedList<>();
+        queue.add(person);
+        int time = 0;
+
+        while (!queue.isEmpty()) {
+            Queue<Point> nextFires = new LinkedList<>();
+            Queue<Point> next = new LinkedList<>();
+            time++;
+
+            moveFires(map, fires, nextFires);
+
+            if (movePerson(map, queue, time, next)) {
+                return String.valueOf(time);
+            }
+
+            queue = next;
+            fires = nextFires;
+        }
+
+        return "IMPOSSIBLE";
+    }
+
+    private static boolean movePerson(char[][] map, Queue<Point> queue, int time, Queue<Point> next) {
+        while (!queue.isEmpty()) {
+            Point cur = queue.poll();
+
+            for (int[] dir : dirs) {
+                int x = dir[0] + cur.x;
+                int y = dir[1] + cur.y;
+
+                if (x < 0 || y < 0 || x >= map.length || y >= map[x].length) { // 탈출
+                    return true;
+                } else if (map[x][y] != '.') {
+                    continue;
+                }
+
+                map[x][y] = '#';
+                next.add(new Point(x, y));
+            }
+        }
+
+        return false;
+    }
+
+    private static void moveFires(char[][] map, Queue<Point> fires, Queue<Point> nextFires) {
+        while (!fires.isEmpty()) {
+            Point fire = fires.poll();
+            for (int[] dir : dirs) {
+                int x = dir[0] + fire.x;
+                int y = dir[1] + fire.y;
+
+                if (x < 0 || y < 0 || x >= map.length || y >= map[x].length || map[x][y] != '.') {
+                    continue;
+                }
+
+                map[x][y] = '*';
+                nextFires.add(new Point(x, y));
+            }
+        }
+    }
+
+}
+


### PR DESCRIPTION
### 숫자판 점프
- 브루트포스로 모든 경우의 수를 dfs로 체킹했고 중복 제거는 Set으로 하였습니다.

### 스타트링크
- bfs로 가까운 거리 순으로 순회하였습니다.

### 현수막
- 모든 좌표를 탐색하면서 dfs로 인접한 숫자를 지워가면서 dfs 호출 횟수를 카운팅했습니다.

### 불
- 불과 상근이를 동시에 bfs 돌리면서 시뮬레이션 하였습니다.

### 상범 빌딩
- 3차원에서의 bfs로 풀이하였습니다.

### 트리의 지름
- 방문한 노드를 중간 노드라고 가정하고 연결된 노드들의 최대 길이 2개의 합이 가장 긴 길이 아닐까 라는 아이디어로 풀이하였습니다.
- 모든 노드들을 한 번 씩만 순회하면서 방문처리를 하고, 현재 노드에서 연결된 가장 긴 노드의 길이 2개의 합을 결과 result 변수에 업데이트 하고, 반환은 연결된 노드 중 가장 긴 길이를 반환하게 dfs로 풀이하였습니다.