### PR TITLE
김승우 / 8월 4주차 / 월

### DIFF
--- a/boj/boj14606.java
+++ b/boj/boj14606.java
@@ -1,0 +1,33 @@
+package myAlgo;
+
+import java.util.*;
+
+class Value {
+	static int val;
+	
+	static void func(int n) {
+		if (n <= 1) {
+			return;
+		}
+		
+		int over = (int)(n/2);
+		int under = n - over;
+		
+		val += over*under;
+		
+		func(over);
+		func(under);
+	}
+}
+
+public class Boj14606 {
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+		
+		
+		Value.func(n);
+		
+		System.out.println(Value.val);
+	}
+}

--- a/boj/boj1543.java
+++ b/boj/boj1543.java
@@ -1,0 +1,37 @@
+package myAlgo;
+
+import java.util.*;
+
+public class Boj1543{
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		String s = sc.nextLine();
+		String comp = sc.nextLine();
+		
+		
+		System.out.println(compDup(s, comp));
+	}
+	
+	private static int compDup(String s1, String s2) {
+		
+		int ans = 0;
+		
+		int i = 0;
+		while (i < s1.length()) {
+			if (i+s2.length() > s1.length()) {
+				break;
+			}
+			if (s1.substring(i, i+s2.length()).equals(s2)) {
+				ans += 1;
+				i += s2.length();
+			} else {
+				i++;
+			}
+			
+		}
+		
+		return ans;
+	}
+}
+
+

--- a/boj/boj17103.java
+++ b/boj/boj17103.java
@@ -1,0 +1,51 @@
+package myAlgo;
+
+import java.util.*;
+
+
+class Eratostenes {
+	static final int MAX = 1000001;
+	
+	public int[] list = new int[MAX];
+	
+	public void initPrime() {
+		for (int i = 2; i<MAX; i++) {
+			this.list[i] = i;
+		}
+		
+		for(int i = 2; i<Math.sqrt(MAX); i++) {
+			for(int j = i+i; j < MAX; j+=i) {
+				if (this.list[j] == 0){
+					continue;
+				}
+				this.list[j] = 0;
+			}
+		}
+		
+	}
+	
+}
+
+
+public class Boj17103 {
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		Eratostenes et = new Eratostenes();
+		et.initPrime();
+		
+		int N = sc.nextInt();
+		
+		
+		for(int i = 0; i< N; i++) {
+			int val = sc.nextInt();
+			int curAns = 0;
+			for(int j = 2; j < (int)(val/2)+1; j++) {
+				
+				if (et.list[j] != 0 && et.list[val-j] != 0) {
+					curAns += 1;
+				}
+			}
+			System.out.println(curAns);
+		}
+	}
+}

--- a/boj/boj17484.java
+++ b/boj/boj17484.java
@@ -1,0 +1,70 @@
+package myAlgo;
+
+import java.util.*;
+import java.io.*;
+
+class Dfs {
+	static int val= 100000;
+	
+	static int[] dx = {1, 1, 1};
+	static int[] dy = {-1, 0, 1};
+	
+	static int n;
+	static int m;
+	
+	static void dfs(int x, int y, int pre_direction, int cur_val, int[][] arr) {
+//		System.out.println("x : " + x + " y : " + y);
+//		System.out.println("curVal : " + cur_val);
+		for (int i = 0; i<3; i++) {
+			
+			if(x == n-1) {
+				val = Math.min(cur_val, val);
+				continue;
+			}
+			int tmp_val = cur_val;
+			if (i == pre_direction) {
+				continue;
+			}
+			
+			int nx = x + dx[i];
+			int ny = y + dy[i];
+			
+			if (ny < 0 || ny >= m) {
+				continue;
+			}
+			
+			tmp_val += arr[nx][ny];
+			dfs(nx, ny, i, tmp_val, arr);
+			
+		}
+		return;
+	}
+}
+
+
+public class Boj17484 {
+	public static void main(String[] args) throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		Dfs.n = Integer.parseInt(st.nextToken());
+		Dfs.m = Integer.parseInt(st.nextToken());
+		
+		int[][] arr = new int[Dfs.n][Dfs.m];
+		
+		for(int i = 0; i<Dfs.n; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j<Dfs.m; j++) {
+				arr[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		for(int i = 0; i<Dfs.m; i++) {
+			Dfs.dfs(0, i, -1, arr[0][i], arr);
+		}
+		
+		System.out.println(Dfs.val);
+		
+		
+	}
+}


### PR DESCRIPTION

---
## 🎈boj 5567 - 결혼식
<br>

#### 🗨 해결방법 : BFS, 인접행렬
<br>


#### 📝메모 :
BFS를 이용해서 구현했고, 깊이, 즉 친구의 친구를 넘어가지 않도록 조건문을 달아주었습니다. 해당 연산을 통해 visited 배열 중 방문한 곳만 카운트해서 정답을 찾아냈습니다.
<br>


<br>

---
## 🎈boj 00000 - 양
<br>

#### 🗨 해결방법 : BFS
<br>


#### 📝메모 : 
i) 양이나 늑대의 개수를 먼저 카운트해놓습니다.
ii) 그 후 다시 반복문을 돌며 양이나 늑대를 만나는 경우 현재 탐색에서의 양과 늑대를 카운트해 놓습니다.

> 배열 바깥으로 나가거나, 울타리나 그 외의 영역은 탐색하지 않습니다.

iii) 만약 현재 탐색에서의 양 마릿수가 늑대의 마릿수보다 같거나 작다면 총 양 마릿수에서 현재 양 마릿수를 제합니다. 그 반대의 경우는 늑대를 양과 같이 처리합니다.

iv) 남은 양의 마릿수와 늑대의 마릿수를 출력합니다.
<br>


<br>

---
## 🎈boj 14284 - 간선 이어가기
<br>

#### 🗨 해결방법 : 다익스트라 알고리즘(?), 인접 행렬
<br>


#### 📝메모 : 
도전 방법 1 : 첫 번째는 플로이드 워셜 알고리즘을 이용해서 구현하려고 했으나 시간초과가 났습니다.
도전 방법 2 : 두 번째로 최적화를 시켜야겠다 싶어서 다익스트라 알고리즘을 적용하였습니다. 만약 현재 노드의 방문값(가중치)보다 거쳐서 오는 것의 가중치가 더 낮다면 업데이트 해주는 방식으로 진행하였습니다.

> 다익스트라를 생각하고 코드를 작성하였는데, 혹시 수정해야 할 부분이 있는지, 혹은 최적화할 수 있는 기법이 있는지 알려주시면 감사하겠습니다. 실행 시간이 너무 높게 나와서 질문드립니다.
<br>


<br>

---
## 🎈boj 13424 - 비밀 모임
<br>

#### 🗨 해결방법 : 플로이드 워셜 알고리즘
<br>


#### 📝메모 : 정점의 개수가 적어 $O(V^3), (V$는 정점의 개수)의 시간 복잡도를 가지는 플로이드 워셜 알고리즘으로 접근을 해도 괜찮을 듯 싶었습니다.

모든 방들의 최단 거리를 구한 후, 친구들이 있는 방의 행만 따와서 각 열(방)까지의 거리들을 모두 합해 최소가 되는 방을 구해 출력하였습니다.

<br>


<br>
