### PR TITLE
김승우 / 8월 3, 4주차 / 월, 목  

### DIFF
--- a/Kimseungwoo/boj/boj11058.java
+++ b/Kimseungwoo/boj/boj11058.java
@@ -1,0 +1,31 @@
+package boj;
+
+import java.util.*;
+
+public class boj11058 {
+	
+	static int buf = 0;
+	static long[] lengthDP;
+	static int count;
+	
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		
+		count = sc.nextInt();
+		lengthDP = new long[101];
+		lengthDP[1] = 1;
+		lengthDP[2] = 2;
+		lengthDP[3] = 3;
+		
+		for(int i = 4; i <= count; i++) {
+			lengthDP[i] = lengthDP[i-1]+1;
+			
+			for(int j = i; j >= 3; j--) {
+				lengthDP[i] = Math.max(lengthDP[i], lengthDP[i-j]*(j-1));
+			}
+		}
+		
+		System.out.println(lengthDP[count]);
+	}
+
+}

--- a/Kimseungwoo/boj/boj13424.java
+++ b/Kimseungwoo/boj/boj13424.java
@@ -1,0 +1,96 @@
+package boj;
+
+//비밀 모임 -> implements by Floyd-warshall algorithm!
+
+import java.io.*;
+import java.util.*;
+
+public class boj13424 {
+ static int[][] graph;
+ static int N; // cnt of vertex
+ static int M; // cnt of edge
+
+ static int fNum;
+
+ static int[][] friendsList;
+ static ArrayList<Integer> friendsIdxList;
+ static final int INF = Integer.MAX_VALUE;
+
+ public static void main(String[] args) throws IOException {
+     BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+     int TC = Integer.parseInt(br.readLine());
+     StringBuilder sb = new StringBuilder();
+
+     for(int t = 1; t <= TC; t++){
+         // v, e input
+         StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+         N = Integer.parseInt(st.nextToken());
+         M = Integer.parseInt(st.nextToken());
+
+         graph = new int[N+1][N+1];
+
+         for(int i = 1; i <= N; i++){
+             for(int j = 1; j <= N; j++){
+                 if(i == j) {
+                     graph[i][j] = 0;
+                     continue;
+                 }
+                 graph[i][j] = INF;
+             }
+         }
+
+         for(int i = 0; i < M; i++){
+             st = new StringTokenizer(br.readLine(), " ");
+             int from = Integer.parseInt(st.nextToken());
+             int to = Integer.parseInt(st.nextToken());
+             int weight = Integer.parseInt(st.nextToken());
+
+             graph[from][to] = weight;
+             graph[to][from] = weight;
+         }
+
+         fNum = Integer.parseInt(br.readLine());
+         friendsList = new int[fNum][];
+         friendsIdxList = new ArrayList<>();
+         st = new StringTokenizer(br.readLine(), " ");
+         while(st.hasMoreTokens()){
+             friendsIdxList.add(Integer.parseInt(st.nextToken()));
+         }
+
+         floyd();
+
+         for(int i = 0; i < fNum; i++){
+             friendsList[i] = Arrays.copyOf(graph[friendsIdxList.get(i)], N+1);
+         }
+         int minDistanceRoom = -1;
+         int min = Integer.MAX_VALUE;
+
+         for(int i = 1; i <= N; i++){
+             int sum = 0;
+             for(int j = 0; j < fNum; j++){
+                 sum += friendsList[j][i];
+             }
+             if(sum < min){
+                 min = sum;
+                 minDistanceRoom = i;
+             }
+         }
+
+         sb.append(minDistanceRoom).append("\n");
+     }
+
+     System.out.println(sb);
+ } // end of main
+
+ private static void floyd(){
+     for(int k = 1; k <= N; k++){
+         for(int i = 1; i <= N; i++){
+             for(int j = 1; j <= N; j++){
+                 if(graph[i][k] != INF && graph[k][j] != INF && graph[i][j] > graph[i][k] + graph[k][j]){
+                     graph[i][j] = graph[i][k] + graph[k][j];
+                 }
+             }
+         }
+     }
+ }
+} // end of class

--- a/Kimseungwoo/boj/boj14284.java
+++ b/Kimseungwoo/boj/boj14284.java
@@ -1,0 +1,99 @@
+package boj;
+
+/*
+* 간선 이어가기 2, 다익스트라 알고리즘을 복기해보자!
+* floyd -> 시간 초과 : O(n^3)이라 그런듯..
+* */
+
+import java.io.*;
+import java.util.*;
+
+public class boj14284 {
+
+    static int[][] graph;
+    static int[] distance;
+    static int N; // cnt of vertex
+    static int M; // cnt of edge
+
+    static int ansFrom; // target vertex ans
+    static int ansTo; // target vertex ans
+
+    static final int INF = Integer.MAX_VALUE; // 연결되지 않았을 때의 가중치 지정
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        graph = new int[N+1][N+1]; // adjacent list, storing connection of vertex to vertex.
+        distance = new int[N+1];
+        for(int i = 0; i < M; i++){
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            int weight = Integer.parseInt(st.nextToken());
+
+            graph[from][to] = weight;
+            graph[to][from] = weight;
+        }
+
+        st = new StringTokenizer(br.readLine());
+
+        ansFrom = Integer.parseInt(st.nextToken());
+        ansTo = Integer.parseInt(st.nextToken());
+
+        // initiate graph and distance process
+        for(int i = 1; i <= N; i++){
+            for(int j = 1; j <= N; j++){
+                if(i == ansFrom){
+                    if(graph[i][j] == 0){
+                        graph[i][j] = INF;
+                        distance[j] = INF;
+                    }
+                    else {
+                        distance[j] = graph[i][j];
+                    }
+                }
+
+                if(graph[i][j] == 0) graph[i][j] = INF;
+            }
+        }
+        //floyd();
+        distance[ansFrom] = 0;
+        dijkstra(ansFrom);
+        System.out.println(distance[ansTo]);
+
+    } // end of main
+
+    private static void dijkstra(int start){
+        Queue<Integer> q = new ArrayDeque<>();
+        q.offer(start);
+        while(!q.isEmpty()){
+            int v = q.poll();
+            for(int i = 1; i <= N; i++){
+                if(i == v) continue;
+                if(graph[v][i] != INF){ // 해당 정점과 연결된 것일때만 체크
+                    if(distance[i] >= graph[v][i] + distance[v]) {
+                        distance[i] = graph[v][i] + distance[v];
+                    } else continue;
+                    q.offer(i);
+                }
+            }
+        }
+
+    }
+
+    private static void floyd(){
+        for(int k = 1; k <= N; k++){
+            for(int i = 1; i <= N; i++){
+                for(int j = 1; j <= N; j++){
+                    if((graph[i][k] != INF && graph[k][j] != INF) && graph[i][j] > graph[i][k] + graph[k][j]){
+                        graph[i][j] = graph[i][k] + graph[k][j];
+                    }
+                }
+            }
+        }
+    }
+} // end of class

--- a/Kimseungwoo/boj/boj16401.java
+++ b/Kimseungwoo/boj/boj16401.java
@@ -1,0 +1,62 @@
+package boj;
+
+import java.io.*;
+import java.util.*;
+
+public class boj16401 {
+
+    static int M; // 조카의 수
+    static int N; // 과자의 수
+    static int max = Integer.MIN_VALUE; // 최대 과자의 길이
+
+    static int[] cookie;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        M = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+        cookie = new int[N];
+
+        st = new StringTokenizer(br.readLine(), " ");
+        int max_length = -1;
+        int min_length = Integer.MIN_VALUE;
+        for(int i = 0; i < N; i++){
+            cookie[i] = Integer.parseInt(st.nextToken());
+            if(max_length < cookie[i]){
+                max_length = cookie[i];
+            }
+            if(min_length > cookie[i]){
+                min_length = cookie[i];
+            }
+        }
+
+        binarySearch(1, max_length); // 만약 현재 저장된 길이보다 작게 자르는 것이라면 재귀를 그만함
+        if(max == Integer.MIN_VALUE){
+            System.out.println(0);
+        } else {
+            System.out.println(max);
+        }
+        
+    } // 81퍼에서 틀림!
+
+    private static void binarySearch(int start, int end){
+        if(start > end) {
+            return;
+        }
+        int divNum = 0;
+        int mid = (start+end)/2;
+        for(int i = 0; i<N; i++){
+            divNum += cookie[i]/mid;
+        }
+        if(divNum >= M){ // 충분히 자르고도 남는 경우
+            if(mid > max) {
+                max = mid;
+            }
+            binarySearch(mid+1, end);
+        } else { // 자르기가 부족한 경우
+            binarySearch(start, mid-1);
+        }
+    }
+}
+

--- a/Kimseungwoo/boj/boj3184.java
+++ b/Kimseungwoo/boj/boj3184.java
@@ -1,0 +1,108 @@
+package boj;
+
+import java.io.*;
+import java.util.*;
+
+public class boj3184{
+
+    static int totalSheepCnt;
+    static int totalWolfCnt;
+
+    static int R; // row
+    static int C; // column;
+
+    // direction array
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, -1, 0, 1};
+
+    static char[][] map;
+    static boolean[][] visited;
+
+    static class Location{
+        int x, y;
+        Location(int x, int y){
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        R = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+        map = new char[R][];
+        visited = new boolean[R][C];
+
+        for(int i = 0; i < R; i++){
+            map[i] = br.readLine().toCharArray();
+        }
+
+        for(int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                if (map[i][j] == 'o') totalSheepCnt++;
+                if (map[i][j] == 'v') totalWolfCnt++;
+            }
+        }
+
+        for(int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                if(visited[i][j]) continue;
+                if(map[i][j] == 'o' || map[i][j] == 'v') {
+                    bfs(i, j);
+                }
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(totalSheepCnt).append(" ").append(totalWolfCnt);
+
+        System.out.println(sb);
+    } // end of main
+
+    private static void bfs(int i, int j){
+        Queue<Location> q = new ArrayDeque<>();
+        q.offer(new Location(i, j));
+        visited[i][j] = true;
+        int curWolfCnt = 0;
+        int curSheepCnt = 0;
+
+        if(map[i][j] == 'o') curSheepCnt++;
+        else curWolfCnt++;
+
+        /*
+        * if curWolfCnt >= curSheepCnt then totalSheepCnt -= curSheepCnt
+        * else totalWolfCnt -= curWolfCnt
+        * */
+
+        while(!q.isEmpty()){
+            Location lc = q.poll();
+            int x = lc.x;
+            int y = lc.y;
+
+            for(int k = 0; k < 4; k++){
+                int nx = x + dx[k];
+                int ny = y + dy[k];
+
+                if(checkPs(nx, ny) && !visited[nx][ny]){
+                    if(map[nx][ny] == 'o') curSheepCnt++;
+                    else if(map[nx][ny] == 'v') curWolfCnt++;
+
+                    visited[nx][ny] = true;
+                    q.offer(new Location(nx, ny));
+                }
+            }
+        }
+        if(curWolfCnt >= curSheepCnt){
+            totalSheepCnt -= curSheepCnt;
+        } else {
+            totalWolfCnt -= curWolfCnt;
+        }
+    }
+
+
+    private static boolean checkPs(int x, int y){
+        return (x < 0 || y < 0 || x >= R || y >= C || map[x][y] == '#') ? false : true;
+    }
+} // end of class

--- a/Kimseungwoo/boj/boj5567.java
+++ b/Kimseungwoo/boj/boj5567.java
@@ -1,0 +1,69 @@
+package boj;
+
+import java.io.*;
+import java.util.*;
+
+public class boj5567 {
+
+    static int N; // 동기의 수
+    static int M; // 리스트의 길이
+
+    static int[][] friendsGraph; // 친구간의 관계를 나타낼 인접 리스트
+    static boolean[] visited; // 해당 친구를 초대 리스트에 넣었는지 확인할 배열
+
+    static class Friend {
+        int fNum;
+        int depth;
+        Friend(int fNum, int depth){
+            this.fNum = fNum;
+            this.depth = depth;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        M = Integer.parseInt(br.readLine());
+
+        friendsGraph = new int[N+1][N+1];
+        visited = new boolean[N+1];
+
+        for(int i = 0; i < M; i++){
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+
+            friendsGraph[from][to] = 1;
+            friendsGraph[to][from] = 1;
+        }
+
+        bfs(1); // 상근이부터 탐색!
+
+        int ans = 0;
+        for(int i = 2; i <= N; i++){
+            if(visited[i]) ans++;
+        }
+
+        System.out.println(ans);
+    }
+
+    private static void bfs(int start){
+        Queue<Friend> q = new ArrayDeque<>();
+        q.offer(new Friend(start, 0));
+        visited[start] = true;
+
+        while(!q.isEmpty()){
+            Friend fInfo = q.poll();
+            int fNumb = fInfo.fNum;
+            int depth = fInfo.depth;;
+
+            for(int i = 1; i < N+1; i++){
+                if(!visited[i] && friendsGraph[fNumb][i] == 1){
+                    if(depth + 1 > 2) return;
+                    visited[i] = true;
+                    q.offer(new Friend(i, depth+1));
+                }
+            }
+        }
+    }
+}

--- a/Kimseungwoo/boj/boj7795.java
+++ b/Kimseungwoo/boj/boj7795.java
@@ -1,0 +1,62 @@
+package boj;
+
+import java.io.*;
+import java.util.*;
+
+public class boj7795 {
+
+    static int min = -1;
+    private static int[] arr1;
+    private static int[] arr2;
+
+    private static int ans = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        for(int tc = 0; tc < T; tc++){
+            StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+            arr1 = new int[Integer.parseInt(st.nextToken())];
+            arr2 = new int[Integer.parseInt(st.nextToken())];
+
+            st = new StringTokenizer(br.readLine(), " ");
+            for(int i = 0; i < arr1.length; i++){
+                arr1[i] = Integer.parseInt(st.nextToken());
+            }
+            st = new StringTokenizer(br.readLine(), " ");
+            for(int i = 0; i < arr2.length; i++){
+                arr2[i] = Integer.parseInt(st.nextToken());
+            }
+
+            Arrays.sort(arr1);
+            Arrays.sort(arr2);
+
+            for(int i = 0; i<arr1.length; i++){
+                binarySearch(arr1[i], 0, arr2.length-1);
+                ans += min+1;
+                min = -1;
+            }
+            System.out.println(ans);
+            ans = 0;
+        }
+    }
+
+    private static void binarySearch(int target, int start, int end){
+        if(start > end){
+            return;
+        }
+        int mid = (end+start)/2;
+
+        if(arr2[mid] < target) {
+            if (min < mid) {
+                min = mid;
+            }
+            binarySearch(target, mid+1, end);
+
+        } else {
+            binarySearch(target, start, mid-1);
+        }
+    }
+}
+


### PR DESCRIPTION
---
## 🎈boj 7795 - 먹을 것인가 먹힐 것인가
<br>

#### 🗨 해결방법 : 이분탐색
<br>


#### 📝메모 : 먼저 배열을 정렬해놓은 후, A 배열의 특정 인덱스의 값보다 작은 값을 찾기 위해 이분탐색을 진행하였습니다. 해당 인덱스를 찾게 되면 인덱스보다 작은 값들은 모두 현재 인덱스의 값보다 작은 것이므로 더해서 처리하였습니다.

<br>


<br>

---
## 🎈boj 16401 - 과자 나눠주기
<br>

#### 🗨 해결방법 : 이분탐색
<br>


#### 📝메모 : 조카 모두에게 나눠 줄 수 있는 과자를 자를 수 있는 크기 기준으로 이분탐색으로 구현하여 찾고, 해당 값보다 더 길게 자르는 방법이 있을 수도 있으므로 갱신해놓고 그 위의 값들도 이분탐색하여 최대값을 찾았습니다.

<br>


---
## 🎈boj 11058 - 크리보드
<br>

#### 🗨 해결방법 : DP, 반복문
<br>


#### 📝메모 : 전체를 복사하여 붙이는 것과, 현재 버퍼에 남아 있는 값들을 붙이는 것으로 MAX 비교를 진행했고, 크다면 현재의 최대값을 갱신하여 구현하였습니다.

<br>



<br>

---
## 🎈boj 5567 - 결혼식
<br>

#### 🗨 해결방법 : BFS, 인접행렬
<br>


#### 📝메모 :
BFS를 이용해서 구현했고, 깊이, 즉 친구의 친구를 넘어가지 않도록 조건문을 달아주었습니다. 해당 연산을 통해 visited 배열 중 방문한 곳만 카운트해서 정답을 찾아냈습니다.
<br>


<br>

---
## 🎈boj 3184 - 양
<br>

#### 🗨 해결방법 : BFS
<br>


#### 📝메모 : 
i) 양이나 늑대의 개수를 먼저 카운트해놓습니다.
ii) 그 후 다시 반복문을 돌며 양이나 늑대를 만나는 경우 현재 탐색에서의 양과 늑대를 카운트해 놓습니다.

> 배열 바깥으로 나가거나, 울타리나 그 외의 영역은 탐색하지 않습니다.

iii) 만약 현재 탐색에서의 양 마릿수가 늑대의 마릿수보다 같거나 작다면 총 양 마릿수에서 현재 양 마릿수를 제합니다. 그 반대의 경우는 늑대를 양과 같이 처리합니다.

iv) 남은 양의 마릿수와 늑대의 마릿수를 출력합니다.
<br>


<br>

---
## 🎈boj 14284 - 간선 이어가기
<br>

#### 🗨 해결방법 : 다익스트라 알고리즘(?), 인접 행렬
<br>


#### 📝메모 : 
도전 방법 1 : 첫 번째는 플로이드 워셜 알고리즘을 이용해서 구현하려고 했으나 시간초과가 났습니다.
도전 방법 2 : 두 번째로 최적화를 시켜야겠다 싶어서 다익스트라 알고리즘을 적용하였습니다. 만약 현재 노드의 방문값(가중치)보다 거쳐서 오는 것의 가중치가 더 낮다면 업데이트 해주는 방식으로 진행하였습니다.

> 다익스트라를 생각하고 코드를 작성하였는데, 혹시 수정해야 할 부분이 있는지, 혹은 최적화할 수 있는 기법이 있는지 알려주시면 감사하겠습니다. 실행 시간이 너무 높게 나와서 질문드립니다.
<br>


<br>

---
## 🎈boj 13424 - 비밀 모임
<br>

#### 🗨 해결방법 : 플로이드 워셜 알고리즘
<br>


#### 📝메모 : 정점의 개수가 적어 $O(V^3), (V$는 정점의 개수)의 시간 복잡도를 가지는 플로이드 워셜 알고리즘으로 접근을 해도 괜찮을 듯 싶었습니다.

모든 방들의 최단 거리를 구한 후, 친구들이 있는 방의 행만 따와서 각 열(방)까지의 거리들을 모두 합해 최소가 되는 방을 구해 출력하였습니다.

<br>


<br>