### PR TITLE
김승우 / 8월 5주차 / 월

### DIFF
--- a/Kimseungwoo/boj/boj14497.java
+++ b/Kimseungwoo/boj/boj14497.java
@@ -1,0 +1,75 @@
+package toyproject.somedaybucket.myAlgo.boj;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class boj14497 {
+
+    static char[][] map;
+    static int N, M;
+    static int jx, jy;
+    static int bx, by;
+
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, -1, 0, 1};
+
+    static int count = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        jx = Integer.parseInt(st.nextToken())-1;
+        jy = Integer.parseInt(st.nextToken())-1;
+        bx = Integer.parseInt(st.nextToken())-1;
+        by = Integer.parseInt(st.nextToken())-1;
+
+        map = new char[N][M];
+
+        for(int i = 0; i < N; i++){
+            map[i] = br.readLine().toCharArray();
+        }
+
+        jump(jx, jy);
+
+        System.out.println(count);
+    }
+
+    private static void jump(int i, int j){
+        int curJump = 0;
+        while(true){
+            bfs(i, j, ++curJump, new boolean[N][M]);
+            if(count > 0) break;
+        }
+    }
+
+    private static void bfs(int i, int j, int cnt, boolean[][] visited){
+
+        if (i == bx && j == by){
+            count = cnt;
+            return;
+        }
+
+        if(map[i][j] == '1'){
+            map[i][j] = '0';
+            return;
+        }
+
+        for(int k = 0; k < 4; k++){
+            int nx = i + dx[k];
+            int ny = j + dy[k];
+            if(!checkPos(nx, ny)) continue;
+            if(visited[nx][ny]) continue;
+
+            visited[nx][ny] = true;
+            bfs(nx, ny, cnt, visited);
+        }
+    }
+
+    private static boolean checkPos(int i, int j){
+        return (i < 0 || j < 0 || i >= N || j >= M) ? false : true;
+    }
+}

--- a/Kimseungwoo/boj/boj16198.java
+++ b/Kimseungwoo/boj/boj16198.java
@@ -1,0 +1,45 @@
+package toyproject.somedaybucket.myAlgo.boj;
+
+import java.io.*;
+import java.util.*;
+
+public class boj16198 {
+
+    static int N;
+    static long max = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        ArrayList<Integer> a = new ArrayList<>();
+
+        for(int i = 0; i < N; i++){
+            a.add(Integer.parseInt(st.nextToken()));
+        }
+
+        getEnergy(N, 0, a);
+        System.out.println(max);
+    }
+
+    private static void getEnergy(int n, long curSum, ArrayList<Integer> paramArr){
+        if(n == 2){
+            if(max < curSum) max = curSum;
+            return;
+        }
+
+        for(int i = 1; i < paramArr.size()-1; i++){
+            int tmp = paramArr.get(i);
+            int energy = paramArr.get(i-1)*paramArr.get(i+1);
+            paramArr.remove(i);
+            getEnergy(n-1, curSum+energy, paramArr);
+            paramArr.add(i, tmp);
+
+        }
+    }
+
+
+}

--- a/Kimseungwoo/boj/boj17265.java
+++ b/Kimseungwoo/boj/boj17265.java
@@ -1,0 +1,79 @@
+package toyproject.somedaybucket.myAlgo.boj;
+
+// boj 17265 - 나의 인생에는 숫자와 함께
+
+import java.io.*;
+import java.util.*;
+
+public class boj17265 {
+
+    static char[][] map;
+    static int N;
+    static int max = Integer.MIN_VALUE;
+    static int min = Integer.MAX_VALUE;
+    static int[] dx = {1, 0};
+    static int[] dy = {0, 1};
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        map = new char[N][N];
+
+        for(int i = 0; i < N; i++){
+            StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+            for(int j = 0; j < N; j++){
+                map[i][j] = st.nextToken().charAt(0);
+            }
+        }
+
+        bfs(0, 0, map[0][0]-'0', ' ');
+        System.out.println(max + " " + min);
+    }
+
+    private static void bfs(int i, int j, int preVal, char operator){
+        int val = preVal;
+        if(i == N-1 && j == N-1){
+            int curVal = map[i][j]-'0';
+            int ans = operation(preVal, curVal, operator);
+            if(ans > max) max = ans;
+            if(ans < min) min = ans;
+
+            return;
+        }
+        if(checkOp(operator)){ // 숫자가 나왔을 때
+            val = operation(preVal, map[i][j]-'0', operator);
+        }
+        for(int k = 0; k < 2; k++){
+            int nx = i + dx[k];
+            int ny = j + dy[k];
+
+            if(!checkPos(nx, ny)) continue;
+
+            bfs(nx, ny, val, map[i][j]);
+        }
+    }
+    private static boolean checkPos(int i, int j){
+        return (i >= N || j >= N) ? false : true;
+    }
+    private static boolean checkOp(char op){
+        return (op == '*' || op == '+' || op == '-') ? true : false;
+    }
+
+
+    private static int operation(int pre, int cur, char op){
+        int ret = pre;
+        switch (op){
+            case '*' :
+                ret = pre * cur;
+                break;
+            case '+' :
+                ret = pre + cur;
+                break;
+            case '-' :
+                ret = pre - cur;
+                break;
+        }
+
+        return ret;
+    }
+}

--- a/Kimseungwoo/boj/boj1802.java
+++ b/Kimseungwoo/boj/boj1802.java
@@ -1,0 +1,44 @@
+package toyproject.somedaybucket.myAlgo.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class boj1802 {
+
+    static char[] paper;
+    static int half;
+    static int count;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int TC = Integer.parseInt(br.readLine());
+
+        for(int i = 0; i < TC; i++){
+            paper = br.readLine().toCharArray();
+            half = paper.length/2;
+
+            int start = 0;
+            int end = paper.length-1;
+
+            if(foldPaper(start, end)){
+                System.out.println("YES");
+            } else {
+                System.out.println("NO");
+            }
+            count = 0;
+        }
+    } // end of main
+
+    private static boolean foldPaper(int start, int end){
+        if(start >= end) return true;
+        int mid = start + (end - start)/2;
+
+        for(int i = start; i < mid; i++){
+            if(paper[i] == paper[end-i]) return false;
+        }
+
+        return foldPaper(start, mid-1) && foldPaper(mid+1, end);
+    }
+} // end of class


### PR DESCRIPTION
---
## 🎈boj 16198 - 에너지 구슬
<br>

#### 🗨 해결방법 : 재귀함수
<br>


#### 📝메모 : 두 개가 남을 때 까지 재귀를 돌려서 모든 경우의 수를 셀 수 있도록 하였습니다.
현재 공을 뺐다가 일련의 과정들이 끝나면 다시 넣어서 그 구슬을 없애지 않았을 때의 경우도 계산할 수 있게 하였습니다.
<br>

---
## 🎈boj 1802 - 종이 접기
<br>

#### 🗨 해결방법 : 이분탐색
<br>


#### 📝메모 : 종이를 접었을 때의 가운데를 기준으로 양쪽이 모두 달라야 하므로, 모든 중간값을 이분탐색을 이용해 찾고, 양쪽을 확인해주는 작업을 진행하였습니다.
<br>

---
## 🎈boj 17265 - 나의 인생은 수학과 함께
<br>

#### 🗨 해결방법 : DFS
<br>


#### 📝메모 : 숫자가 나올 경우, 이전의 기억하고 있던 연산자를 꺼내 계산을 진행할 수 있도록 하였습니다. 또한, 연산자를 기억하는 것과 마찬가지로 숫자 또한 이전에 나온 숫자를 기억할 수 있도록 하여 최대값과 최소값을 각각 탐색하였습니다.
<br>

---
## 🎈boj 14497 - 주난의 난
<br>

#### 🗨 해결방법 : BFS
<br>


#### 📝메모 : 주난이가 있는 곳에서 DFS를 진행하되, 1을 만날 경우 0으로 변경 후 탐색을 멈추도록 하였습니다. 한 번씩 진행할 때마다 점프의 횟수를 cnt 매개변수로 넘겼고, 범인을 만났을 때 카운트를 변경하여 while문을 빠져나올 수 있게 하였습니다. 또한, 점프를 할 때마다 새로운 방문처리 배열을 넣어 이전의 점프가 다음의 점프에 영향이 가지 않도록 하였습니다.
<br>
