### PR TITLE
소재열 / 9월 4주차 / 월 

### DIFF
--- a/jaeyeol/boj/Boj20917.java
+++ b/jaeyeol/boj/Boj20917.java
@@ -1,0 +1,81 @@
+package problem.baekjoon.binarySearch;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Boj20917 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = Integer.parseInt(br.readLine());
+        StringBuilder result = new StringBuilder();
+
+        while (t-- > 0) {
+            StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+            int n = Integer.parseInt(st.nextToken());
+            int s = Integer.parseInt(st.nextToken());
+
+            int[] arr = new int[n];
+            st = new StringTokenizer(br.readLine(), " ");
+            for (int i = 0; i < n; i++) {
+                arr[i] = Integer.parseInt(st.nextToken());
+            }
+
+            result.append(getMaxDistance(arr, s - 1)).append("\n");
+        }
+
+        System.out.print(result);
+    }
+
+    private static int getMaxDistance(int[] arr, int amount) {
+        Arrays.sort(arr);
+        int right = arr[arr.length - 1] - arr[0];
+        int left = getLeft(arr);
+
+        while (left <= right) {
+            int mid = (left + right) >> 1;
+
+            if (isPossible(arr, mid, amount)) {
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+
+        return right;
+    }
+
+    private static int getLeft(int[] arr) {
+        int left = Integer.MAX_VALUE;
+        int prev = arr[0];
+
+        for (int i = 1; i < arr.length; i++) {
+            int temp = arr[i];
+            arr[i] -= prev;
+            left = Math.min(left, arr[i]);
+            prev = temp;
+        }
+
+        return left;
+    }
+
+    private static boolean isPossible(int[] arr, int minDistance, int amount) {
+        int dist = 0;
+        for (int i = 1; i < arr.length; i++) {
+            dist += arr[i];
+            if (dist >= minDistance) {
+                if (--amount <= 0) {
+                    return true;
+                }
+                dist = 0;
+            }
+        }
+
+        return false;
+    }
+
+}
+

--- a/jaeyeol/boj/Boj27114.java
+++ b/jaeyeol/boj/Boj27114.java
@@ -1,0 +1,48 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Boj27114 {
+    static final int MAX = 10_000_000;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        int a = Integer.parseInt(st.nextToken());
+        int b = Integer.parseInt(st.nextToken());
+        int c = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        System.out.println(getMinCount(a, b, c, k));
+    }
+
+    private static int getMinCount(int a, int b, int c, int k) {
+        int[][] dp = new int[k + 1][4];
+        Arrays.fill(dp[0], MAX);
+        dp[0][0] = 0;
+
+        for (int i = 1; i <= k; i++) {
+
+            for (int dir = 0; dir < 4; dir++) {
+                dp[i][dir] = MAX;
+
+                if (i >= a) {
+                    dp[i][dir] = Math.min(dp[i][dir], dp[i - a][(dir + 3) % 4] + 1);
+                }
+
+                if (i >= b) {
+                    dp[i][dir] = Math.min(dp[i][dir], dp[i - b][(dir + 1) % 4] + 1);
+                }
+
+                if (i >= c) {
+                    dp[i][dir] = Math.min(dp[i][dir], dp[i - c][(dir + 2) % 4] + 1);
+                }
+            }
+        }
+
+        return dp[k][0] >= MAX ? -1 : dp[k][0];
+    }
+
+}
+

--- a/jaeyeol/boj/Boj28106.java
+++ b/jaeyeol/boj/Boj28106.java
@@ -1,0 +1,86 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Boj28106 {
+    static class Node {
+        int power;
+        List<Integer> child = new ArrayList<>();
+    }
+    static int[] dp, list;
+    static int top;
+    static Node[] graph;
+
+    static final int MOD = 998_244_353;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int root = getRootAndSetGraph(n, br);
+        dp = new int[n + 1];
+        list = new int[n + 1];
+        Arrays.fill(dp, -1);
+
+        System.out.println(getCases(root));
+    }
+
+    private static int getRootAndSetGraph(int n, BufferedReader br) throws IOException {
+        graph = new Node[n + 1];
+        for (int i = 0; i <= n; i++) {
+            graph[i] = new Node();
+        }
+        int root = 0;
+
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        for (int node = 1; node <= n; node++) {
+            int parent = Integer.parseInt(st.nextToken());
+            graph[parent].child.add(node);
+            if (parent == 0) {
+                root = node;
+            }
+        }
+
+        st = new StringTokenizer(br.readLine(), " ");
+        for (int node = 1; node <= n; node++) {
+            graph[node].power = Integer.parseInt(st.nextToken());
+        }
+
+        return root;
+    }
+
+    private static int getCases(int node) {
+        if (graph[node].child.isEmpty()) {
+            return 1;
+        } else if (graph[node].power == 0) {
+            return 0;
+        } else if (dp[node] >= 0) {
+            return dp[node];
+        }
+
+        top = 0;
+        setMovableChildList(node, graph[node].power, 0);
+
+        int sum = 0;
+        for (int child : Arrays.copyOf(list, top)) {
+            sum += getCases(child);
+            sum %= MOD;
+        }
+
+        return dp[node] = sum;
+    }
+
+
+    private static void setMovableChildList(int node, int power, int distance) {
+        if (distance >= power) {
+            return;
+        }
+
+        for (int child : graph[node].child) {
+            list[top++] = child;
+            setMovableChildList(child, power, distance + 1);
+        }
+    }
+
+}
+

--- a/jaeyeol/boj/Boj28333.java
+++ b/jaeyeol/boj/Boj28333.java
@@ -1,0 +1,86 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Boj28333 {
+    static class Node {
+        int to;
+        Node next;
+
+        public Node(int to, Node next) {
+            this.to = to;
+            this.next = next;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder result = new StringBuilder();
+        int t = Integer.parseInt(br.readLine());
+
+        while (t-- > 0) {
+            StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+            int n = Integer.parseInt(st.nextToken());
+            int m = Integer.parseInt(st.nextToken());
+            Node[] graph = new Node[n + 1];
+            Node[] reverseGraph = new Node[n + 1];
+            for (int i = 1; i <= n; i++) {
+                graph[i] = new Node(i, null);
+                reverseGraph[i] = new Node(i, null);
+            }
+            for (int i = 0; i < m; i++) {
+                st = new StringTokenizer(br.readLine(), " ");
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+                graph[a].next = new Node(b, graph[a].next);
+                reverseGraph[b].next = new Node(a, reverseGraph[b].next);
+            }
+
+            boolean[] visited = getShortestPath(n, graph, reverseGraph);
+            for (int i = 1; i < visited.length; i++) {
+                if(visited[i]) {
+                    result.append(i).append(' ');
+                }
+            }
+            result.append('\n');
+        }
+
+        System.out.print(result);
+    }
+
+    static final Queue<Integer> queue = new ArrayDeque<>();
+    private static boolean[] getShortestPath(int n, Node[] graph, Node[] reverseGraph) {
+        int[] distances = new int[n + 1];
+        Arrays.fill(distances, n + 1);
+        distances[1] = 0;
+        queue.add(1);
+
+        while (!queue.isEmpty()) {
+            int cur = queue.poll();
+
+            for (Node next = graph[cur].next; next != null; next = next.next) {
+                if (distances[cur] + 1 < distances[next.to]) {
+                    distances[next.to] = distances[cur] + 1;
+                    queue.add(next.to);
+                }
+            }
+        }
+
+        boolean[] visited = new boolean[n + 1];
+        dfs(reverseGraph, distances, visited, n);
+
+        return visited;
+    }
+
+    private static void dfs(Node[] graph, int[] distances, boolean[] visited, int cur) {
+        visited[cur] = true;
+
+        for (Node next = graph[cur].next; next != null; next = next.next) {
+            if (distances[next.to] == distances[cur] - 1 && !visited[next.to]) { // 이 경로로 온거면
+                dfs(graph, distances, visited, next.to);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
---
## 🎈boj 28333 - 화이트칼라
<br>

#### 🗨 해결방법 :
bfs로 각 노드의 distance를 기록하고
역추적으로 탐색하면서 건너왔던 길을 모두 저장하고 출력한다.
<br>


<br>

---
## 🎈boj27114 - 조교의 맹연습
<br>

#### 🗨 해결방법 :
k개의 에너지와 4방향의 최소값을 저장하고, 이전 값을 참조하는 냅색 dp 방식으로 풀었습니다.

<br>

---
## 🎈boj 28106- 나무 타기
<br>

#### 🗨 해결방법 :
현재 루트 노드에서 점프할 수 있는 모든 노드리스트를 구하고, 다음 노드로 가서 탐색합니다.
리프 노드라면 1을 반환하고, 간 노드들의 모든 경우의 수 합을 dp 배열에 저장합니다.
<br>


<br>

---
## 🎈boj 20917- 사회적 거리 두기
<br>

#### 🗨 해결방법 :
parametric search

매개변수 이분 탐색을 통해서 답을 유추한다.

매개변수의 범위는
최소값은 가장 간격이 짧은 거리
최대값은 모든 간격의 합  

isPossible()의 경우 구간을 지나가면서 간격을 더해주고 minDistance보다 크면 콘센트를 선택한다. 콘센트를 모두 소모했다면 true 아니면 false 이다.
<br>

